### PR TITLE
EEPROM: add uploader to change the content of the emulated EEPROM

### DIFF
--- a/i2c.js
+++ b/i2c.js
@@ -244,6 +244,11 @@ function I2C_EEPROM(Zeal, I2C, content) {
         }
     }
 
+    function loadFile(binary) {
+        for (var i = 0; i < binary.length; i++)
+            data[i] = binary.charCodeAt(i);
+    }
+
     /* Format the EEPROM to use ZealFS */
     if (!content) {
         data[0] = 0x5A;
@@ -301,4 +306,5 @@ function I2C_EEPROM(Zeal, I2C, content) {
     this.read = read;
     this.write = write;
     this.write_read = write_read;
+    this.loadFile = loadFile;
 }

--- a/index.html
+++ b/index.html
@@ -47,6 +47,8 @@
         <input type="file" id="file-input" placeholder="OS file" />
         <label for="file-dump">Binary disassembly dump:</label>
         <input type="file" id="file-dump" placeholder="OS dump" />
+        <label for="eeprom-bin">EEPROM image:</label>
+        <input type="file" id="eeprom-bin" placeholder="EEPROM image" />
         <button id="read-button">Read file(s)</button>
         <div id="statuspan">
           <h4>Ready?</h4>

--- a/zeal.js
+++ b/zeal.js
@@ -505,6 +505,17 @@ $("#read-button").on('click', function() {
     if (typeof file !== "undefined") {
         reader.readAsBinaryString(file);
     }
+
+    /* Read the EEPROM image */
+    file = $("#eeprom-bin")[0].files[0];
+    let eepromr = new FileReader();
+    eepromr.addEventListener('load', function(e) {
+        let binary = e.target.result;
+        eeprom.loadFile(binary);
+    });
+    if (typeof file !== "undefined") {
+        eepromr.readAsBinaryString(file);
+    }
 });
 
 


### PR DESCRIPTION
Upload eeprom should be an important funtion to this project, but the newest branch only change the style of the bottons without this funtion.