### PR TITLE
Adjust Layout to reduce Tab Overlap

### DIFF
--- a/view/css/emulator.css
+++ b/view/css/emulator.css
@@ -68,6 +68,7 @@ input[type=text] {
 #toppanel {
     display: flex;
     justify-content: space-between;
+    margin-bottom: 1em;
 }
 
 #debug {
@@ -132,7 +133,7 @@ hr {
 #container canvas {
     position: absolute;
     top: 0;
-    margin-top: 3em;
+    margin-top: 0.5em;
     background-color: black;
     transform-origin: left top;
     image-rendering: pixelated;

--- a/view/css/emulator.css
+++ b/view/css/emulator.css
@@ -133,7 +133,7 @@ hr {
 #container canvas {
     position: absolute;
     top: 0;
-    margin-top: 0.5em;
+    margin-top: 3em;
     background-color: black;
     transform-origin: left top;
     image-rendering: pixelated;


### PR DESCRIPTION
* reduce top margin on canvas
* increase margin of top panel to push tabs down a bit

![image](https://github.com/user-attachments/assets/109843ea-d48d-4b6d-83d8-2e81fa471e08)
