### PR TITLE
Support for locally hosted Pre-built ROMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn-error.log
 out
 build
 zealemu-*
+roms/*

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "dist-win64": "electron-builder --win --x64",
     "dist-mac": "electron-builder --mac",
     "dist-linux": "electron-builder --linux",
-    "dbg": "live-server ./ --port=1145"
+    "dev": "live-server ./ --port=1145",
+    "get-prebuilt": "node ./tools/get-prebuilt.js"
   },
   "keywords": [],
   "author": {
@@ -30,6 +31,7 @@
     "opn": "^6.0.0"
   },
   "devDependencies": {
+    "live-server": "^1.2.2",
     "@electron-forge/cli": "^7.1.0",
     "@electron-forge/maker-deb": "^7.1.0",
     "@electron-forge/maker-rpm": "^7.1.0",

--- a/tools/get-prebuilt.js
+++ b/tools/get-prebuilt.js
@@ -1,0 +1,71 @@
+const https = require("https");
+const fs = require("fs");
+
+console.log("Getting Pre-built roms");
+
+const prebuilt_json_url = "https://zeal8bit.com/roms/index.json";
+
+const getRom = async (rom) => {
+  const fileName = rom.urls.split("/").slice(-1)[0];
+  const romPath = `roms/${fileName}`
+
+  if (fs.existsSync(`roms/${fileName}`)) {
+    console.log(`Exists roms/${fileName}`);
+    rom.urls = romPath;
+    return rom;
+  }
+
+  return new Promise((resolve, reject) => {
+    https.get(rom.urls, (res) => {
+      process.stdout.write(`Downloading ${rom.urls} `);
+      const content = [];
+      res
+        .on("data", (chunk) => {
+          content.push(chunk);
+        })
+        .on("end", () => {
+          const buffer = Buffer.concat(content);
+          fs.writeFileSync(romPath, buffer);
+          rom.urls = romPath;
+          process.stdout.write("... Done\n");
+          resolve(rom);
+        }).on('error', (err) => {
+          reject(err);
+        });
+    });
+  });
+};
+
+(async () => {
+  const data = await fetch(prebuilt_json_url);
+  json = await data.json();
+
+  const indexFile = {
+    indexversion: json.indexversion,
+    latest: null,
+    nightly: [],
+    stable: [],
+  };
+
+  if (json.latest) {
+    indexFile.latest = await getRom(json.latest).catch((err) => {
+      return json.latest;
+    });
+  }
+  if (json.nightly?.length > 0) {
+    for (let i = 0; i < json.nightly.length; i++) {
+      indexFile.nightly.push(await getRom(json.nightly[i]).catch((err) => {
+        return json.nightly[i];
+      }));
+    }
+  }
+  if (json.stable?.length > 0) {
+    for (let i = 0; i < json.stable.length; i++) {
+      indexFile.stable.push(await getRom(json.stable[i]).catch((err) => {
+        return json.stable[i];
+      }));
+    }
+  }
+
+  fs.writeFileSync(`roms/index.json`, JSON.stringify(indexFile, false, 2));
+})();

--- a/view/readrom.js
+++ b/view/readrom.js
@@ -99,7 +99,8 @@ function switchToAdvancedMode(error) {
  * names and links to all of the available ROMs, the first one will always be the default.
  */
 
-const prebuilt_json_url = "https://zeal8bit.com/roms/index.json";
+const prebuilt_json_url_host = "https://zeal8bit.com";
+const prebuilt_json_url_path = "/roms/index.json";
 
 /*
     Only for debug, I don't hold all of the copyright of the
@@ -131,10 +132,15 @@ function processIndex(index) {
 
 /* Fetch the remote JSON file, and pass the content to the previous function */
 if (!advancedMode) {
-    fetch(prebuilt_json_url)
+    fetch(prebuilt_json_url_host + prebuilt_json_url_path)
         .then(response => response.json())
         .then(response => processIndex(response))
-        .catch(switchToAdvancedMode);
+        .catch(() => {
+            fetch(prebuilt_json_url_path)
+            .then(response => response.json())
+            .then(response => processIndex(response))
+            .catch(switchToAdvancedMode);
+        });
 }
 
 function resetRom() {


### PR DESCRIPTION
* `pnpm get-prebuilt` to retrieve the index.json and all roms
  - only downloads if rom doesn't exist
  - always gets the latest index.json
* rename `pnpm dbg` to `pnpm dev` (more common)
* add `live-server` to package.json
* exclude `roms/` folder from git
* try to get the remote index.json, and fallback to relative index.json, and finally the switchToAdvancedMode