### PR TITLE
Electron Config, Electron Reload, and updated Electron Args

### DIFF
--- a/electron/menubar.js
+++ b/electron/menubar.js
@@ -1,4 +1,4 @@
-const fs = require("node:fs");
+const { app } = require('electron');
 
 module.exports = [
     {

--- a/index.html
+++ b/index.html
@@ -233,16 +233,16 @@
         </div>
 
         <section id="rightpanel">
-        <section class="menu" id="controls">
+          <section class="menu" id="controls">
             <img id="continue" title="Continue (F9)" src="imgs/continue.png" alt="Continue" />
             <img id="step" title="Step (F10)" src="imgs/step.png" alt="Step" />
             <img id="stepover" title="Step Over (F11)" src="imgs/stepover.png" alt="Step over" />
             <img id="stop" title="Stop" src="imgs/stop.png" alt="Stop" />
             <img id="reset" title="Reset" src="imgs/restart.png" alt="Reset">
             <img id="clean" title="Clean" src="imgs/clean.png" alt="Clean">
-        </section>
+          </section>
 
-        <section class="menu">
+          <section class="menu">
             <section class="menutitle">
                 <img class="menuicon" src="imgs/down-arrow.png" />Breakpoints</section>
             <section class="menucontent">
@@ -256,9 +256,9 @@
                     </ul>
                 </section>
             </section>
-        </section>
+          </section>
 
-        <section class="menu">
+          <section class="menu">
             <section class="menutitle">
                 <img class="menuicon" src="imgs/right-arrow.png" />Settings</section>
             <section class="menucontent" style="display: none;">
@@ -268,8 +268,7 @@
                     <option value="light">Light</option>
                 </select>
             </section>
-        </section>
-
+          </section>
         </section>
     </section>
 

--- a/index.js
+++ b/index.js
@@ -9,9 +9,19 @@ const yargs = require("yargs/yargs");
 const { hideBin } = require('yargs/helpers')
 const opn = require('opn');
 const { app, BrowserWindow, Menu, ipcMain, ipcRenderer } = require('electron');
+const ElectronConfig = require('electron-config');
+const config = new ElectronConfig();
 const path = require('node:path');
 const fs = require("node:fs");
-const menuBar = require("./menubar.js");
+const menuBar = require("./electron/menubar.js");
+
+if((process.env.ELECTRON_RELOAD) == '1') {
+    console.log('Electron Reload enabled');
+    require('electron-reload')(__dirname, {
+        electron: path.join(__dirname, 'node_modules', '.bin', 'electron'),
+    });
+}
+
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require('electron-squirrel-startup')) {
@@ -19,16 +29,28 @@ if (require('electron-squirrel-startup')) {
 }
 
 function create_mainWindow() {
-    // Create the browser window.
-    const mainWindow = new BrowserWindow({
+    let opts = {
+        show: false,
         width: 1200,
         height: 800,
+    };
+    Object.assign(opts, config.get("winBounds"));
+
+    // Create the browser window.
+    const mainWindow = new BrowserWindow({
+        ...opts,
         webPreferences: {
             preload: path.join(__dirname, 'preload.js'),
         },
     });
 
-    // and load the index.html of the app.
+    mainWindow.once('ready-to-show', mainWindow.show);
+
+    mainWindow.on("close", function() {
+        config.set('winBounds', mainWindow.getBounds())
+        console.log('config written to', config.path);
+    });
+
     mainWindow.loadFile(path.join(__dirname, 'index.html'));
     return mainWindow;
 }
@@ -48,8 +70,8 @@ app.on('ready', () => {
         return;
     }
     createWindow();
-    ipcMain.on("load", () => {
-        parseArgs(argv);
+    ipcMain.on("load", async () => {
+        await parseArgs(argv);
     });
 });
 
@@ -72,6 +94,12 @@ function getArgs() {
         .help("h").alias("h", "help")
         .usage("Usage: $0 [<options>]")
         .example("$0 --rom v0.4.0-9-ge68eb04 --eeprom /your/eeprom/image", "Start the emulator, use zos v0.4.0-9-ge68eb04 and load /your/eeprom/image to eeprom")
+        .option('hide-advanced', {
+            type: 'boolean',
+            alias: 'a',
+            description: 'Hide the advanced ROM menu',
+            default: false,
+        })
         .option('rom', {
             type: 'string',
             alias: 'r',
@@ -85,7 +113,6 @@ function getArgs() {
             array: true,
             nargs: 1,
         })
-        .array("breakpoint")
         .option('map', {
             type: 'string',
             alias: 'm',
@@ -119,22 +146,52 @@ function getArgs() {
     return argv;
 }
 
-function parseArgs(argv) {
+async function parseArgs(argv) {
+    async function setFileInput(wc, selector, files) {
+      try {
+        wc.debugger.attach("1.1");
+
+        const { root } = await wc.debugger.sendCommand("DOM.getDocument", {});
+        const { nodeId } = await wc.debugger.sendCommand("DOM.querySelector", {
+          nodeId: root.nodeId,
+          selector,
+        });
+
+        await wc.debugger.sendCommand("DOM.setFileInputFiles", {
+          nodeId,
+          files,
+        });
+        return true;
+      } catch (err) {
+        return false;
+      } finally {
+        wc.debugger.detach();
+      }
+    }
+
+    let loadAdvanced = false;
+
     if (argv.rom) {
-        mainWindow.webContents.send('rom', fs.readFileSync(argv.rom));
+        loadAdvanced = await setFileInput(mainWindow.webContents, "#file-rom", [path.resolve(argv.rom)]);
     }
     if (argv.map) {
-        mainWindow.webContents.send('map', fs.readFileSync(argv.map));
+        loadAdvanced = await setFileInput(mainWindow.webContents, "#file-map", [path.resolve(argv.map)]);
     }
     if (argv.eeprom) {
-        mainWindow.webContents.send('eeprom', fs.readFileSync(argv.eeprom));
+        loadAdvanced = await setFileInput(mainWindow.webContents, "#file-eeprom", [path.resolve(argv.eeprom)]);
     }
     if (argv.cf) {
-        mainWindow.webContents.send('cf', fs.readFileSync(argv.cf));
+        loadAdvanced = await setFileInput(mainWindow.webContents, "#file-cf", [path.resolve(argv.cf)]);
     }
+
+    if(loadAdvanced) {
+        mainWindow.webContents.send('load-advanced', { hideAdvanced: argv.hideAdvanced });
+    }
+
     if (argv.breakpoint) {
+        console.log('breakpoints', argv.breakpoint);
         mainWindow.webContents.send('breakpoint', argv.breakpoint);
     }
-    
+
     return argv;
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "electron-forge start",
+    "watch": "ELECTRON_RELOAD=1 electron-forge start",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
@@ -27,6 +28,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "electron-config": "^2.0.0",
     "electron-squirrel-startup": "^1.0.1",
     "opn": "^6.0.0",
     "yargs": "^17.7.2"
@@ -40,6 +42,7 @@
     "@electron-forge/plugin-auto-unpack-natives": "^7.4.0",
     "electron": "^28.3.3",
     "electron-builder": "^24.13.3",
+    "electron-reload": "2.0.0-alpha.1",
     "electron-squirrel-startup": "^1.0.0",
     "live-server": "^1.2.2"
   },

--- a/view/readrom.js
+++ b/view/readrom.js
@@ -35,7 +35,7 @@ function loadMap(file_map) {
                 popup.error("Error while loading map file");
             }
         }).readAsText(file_map);
-    }    
+    }
 }
 
 function loadEEPROM(file_eeprom) {
@@ -227,19 +227,11 @@ setTimeout(() => {
 
 // electron
 if (typeof electronAPI != 'undefined') {
-    electronAPI.on("rom", (data) => {
-        loadRom(array_to_blob(data));
-        rom_loaded = true;
-        zealcom.cont();
-    });
-    electronAPI.on("map", (data) => {
-        loadMap(array_to_blob(data));
-    });
-    electronAPI.on("eeprom", (data) => {
-        loadEEPROM(array_to_blob(data));
-    });
-    electronAPI.on("cf", (data) => {
-        loadCf(array_to_blob(data));
+    electronAPI.on('load-advanced', (data) => {
+        if(!data.hideAdvanced) {
+            $('#romfile').show();
+        }
+        $('#read-button').trigger('click');
     });
 }
 


### PR DESCRIPTION
* move menubar.js into electron/menubars.js to keep root "clean"
* modify parseArgs/readrom to attach the files to the advanced file inputs, to re-use the existing logic for how custom ROMs are loaded (so we don't have to maintain multiple ways of loading custom ROMs)
* added electron-config, and have it remember the window bounds (nice when you have multi-monitors with large screens)
* add `pnpm watch` with electron-reload, which reloads the window, or the entire app after saving changes (useful when working on UI/Styling)