### PR TITLE
Pause/Continue Display, Breakpoint Visiblity

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,7 +234,7 @@
 
         <section id="rightpanel">
           <section class="menu" id="controls">
-            <img id="continue" title="Continue (F9)" src="imgs/continue.png" class="cpuexec" alt="Continue" />
+            <img id="continue" title="Continue (F9)" src="imgs/continue.png" class="cpuexec" alt="Continue" style="display: none;"/>
             <img id="pause" title="Pause (F9)" src="imgs/pause.png" alt="Pause" class="cpuexec hidden" />
             <img id="step" title="Step (F10)" src="imgs/step.png" alt="Step" />
             <img id="stepover" title="Step Over (F11)" src="imgs/stepover.png" alt="Step over" />

--- a/index.html
+++ b/index.html
@@ -269,6 +269,9 @@
                       <option value="light">Light</option>
                   </select>
                 </label>
+                <div id="canvas-smooth">
+                  <label>Canvas Smoothing <input type="checkbox" id="canvas-smooth-val" /></label>
+                </div>
                 <div id="web-serial-settings">
                   <label>Web Serial:</label>
                   <button id="web-serial-connect">Connect Serial</button>

--- a/view/breakpoint.js
+++ b/view/breakpoint.js
@@ -76,7 +76,12 @@ function addBreakpoint(addr, autodelete = false) {
 
     /* Only add the breakpoint to the list if it was manually added by the user, not if step over was clicked */
     if (! bkrobj?.autodelete) {
-        $("#bps").append(`<li data-addr="${addr}">${hex(addr)}</li>`);
+        $li = $(`<li data-addr="${addr}">${hex(addr)}</li>`);
+        $delete = $('<span>x</span>').on('click', () => {
+            deleteBreakpoint(addr);
+        })
+        $li.append($delete);
+        $("#bps").append($li);
         /* If the line is currently being disassembled, mark it as a breakpoint */
         $(`.dumpline[data-addr='${addr}']`).addClass("brk");
     }
@@ -92,6 +97,17 @@ function toggleBreakpoint(brkaddr) {
     /* Toggle enabled field in the breakpoint */
     if (bkrobj != undefined) {
         bkrobj.enabled ^= true;
+    }
+}
+
+function deleteBreakpoint(brkaddr) {
+    /* Find the breakpoint object in the breakpoint list */
+    const index = breakpoints.findIndex(element => element.address == brkaddr);
+
+    if(index >= 0) {
+        breakpoints.splice(index, 1);
+        $(`#bps li[data-addr='${brkaddr}']`).remove();
+        $(`.dumpline[data-addr='${brkaddr}']`).toggleClass("brk");
     }
 }
 

--- a/view/css/emulator.css
+++ b/view/css/emulator.css
@@ -195,12 +195,34 @@ hr {
 }
 
 #bps li {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
     margin-left: -1.2em;
     padding-left: 1.5em;
     line-height: 3em;
     font-family: monospace;
     width: 102%;
     user-select: none;
+
+    > span {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+        line-height: 1em;
+        color: white;
+        text-transform: lowercase;
+        margin-left: auto;
+
+        &:hover {
+            color: rgb(163, 49, 34);
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+    }
 }
 
 #bps li:hover {

--- a/view/css/emulator.css
+++ b/view/css/emulator.css
@@ -143,6 +143,10 @@ hr {
     width: 640px;
     height: 480px;
     image-rendering: pixelated;
+    &.no-pixels {
+        image-rendering: auto;
+        image-rendering: crisp-edges;
+    }
 }
 
 #rightpanel {

--- a/view/css/emulator.css
+++ b/view/css/emulator.css
@@ -587,6 +587,7 @@ h3 {
     &.visible {
         padding-block: 0.5em;
         max-height: 300px;
+        overflow-y: auto;
         transition:
             max-height .125s ease-in,
             padding-block 0.125ms ease-in;

--- a/view/init.js
+++ b/view/init.js
@@ -37,7 +37,7 @@ terminal.open(document.getElementById('terminal'));
 document.addEventListener('keydown', function(event) {
     var handled = false;
     const binding = {
-        'F9': $(".cpuexec:not(.hidden)"),
+        'F9': $(".cpuexec:visible"),
         'F10': $("#step"),
         'F11': $("#stepover")
     };

--- a/view/menus.js
+++ b/view/menus.js
@@ -16,13 +16,13 @@ $("#clean").on("click",    () => {
 
 
 function showPauseView() {
-    $("#continue").addClass("hidden");
-    $("#pause").removeClass("hidden");
+    $("#continue").hide();
+    $("#pause").show();
 }
 
 function showContinueView() {
-    $("#continue").removeClass("hidden");
-    $("#pause").addClass("hidden");
+    $("#continue").show();
+    $("#pause").hide();
 }
 
 
@@ -102,6 +102,9 @@ $('#web-serial-connect').on('click', (e) => {
 });
 
 jQuery(() => {
+    $('#continue').hide();
+    $('#pause').show();
+
     if(!navigator || !navigator.serial) {
         // disable web serial, only supported in latest Chrome, Edge and Opera
         $('#web-serial-settings').hide();

--- a/view/menus.js
+++ b/view/menus.js
@@ -101,9 +101,23 @@ $('#web-serial-connect').on('click', (e) => {
         });
 });
 
+$('#canvas-smooth-val').on('change', (e) => {
+    const smooth = e.currentTarget.checked;
+    localStorage.setItem('canvas-smooth', smooth);
+    console.log('smooth', smooth);
+    if(smooth) {
+        $('#screen').addClass('no-pixels');
+    } else {
+        $('#screen').removeClass('no-pixels');
+    }
+})
+
 jQuery(() => {
     $('#continue').hide();
     $('#pause').show();
+
+    const smooth = localStorage.getItem('canvas-smooth') ?? false;
+    $('#canvas-smooth-val').attr('checked', smooth).trigger('change');
 
     if(!navigator || !navigator.serial) {
         // disable web serial, only supported in latest Chrome, Edge and Opera


### PR DESCRIPTION
* fix the pause/continue display [fixes #35]
* fix breakpoint visibility for long lists [fixes #34]
* delete breakpoint [fixes #34]
* add a setting to enable canvas smoothing (disable pixelated), to prevent pixels from being dropped when zooming out [fixes #27]

Scrollable breakpoint list with "x" to delete
![image](https://github.com/user-attachments/assets/675dba18-dc63-4fa1-b46f-20aa50195937) ![image](https://github.com/user-attachments/assets/04a1e063-4c12-4e1f-8760-d11580bc8f6b)

Canvas Smoothing Setting

The users preferences is stored in localStorage under `canvas-smooth` key, so refreshing will retain the preference.
![image](https://github.com/user-attachments/assets/0c5e18f7-3842-4b86-84ec-0d633b16e59a)
![image](https://github.com/user-attachments/assets/d7d94b07-4fb7-4096-b5f1-af04ae4d6afd)


