### PR TITLE
Improved Memory View (Editable Memory)

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
       <section id="memview" class="panel">
         <section class="panel-toolbar">
           <input type="text" id="dumpaddr" placeholder="Hex address" />
-          <input type="text" id="dumpsize" placeholder="Size" />
+          <input type="text" id="dumpsize" placeholder="Size" value="256" />
           <input type="button" id="dumpnow" value="Dump" />
           <input type="button" id="dump-button" value="Dump ROM" />
           <input type="button" id="dump-eeprom-button" value="Dump EEPROM" />

--- a/view/css/emulator.css
+++ b/view/css/emulator.css
@@ -507,36 +507,60 @@ hr {
 .memaddr {
     display: inline-block;
     color: #268bd2;
+    text-align: right;
     font-weight: bold;
 
     grid-column: 1;
     grid-row: span 2;
 }
+#current_memaddr {
+}
 
 
-.membytes, .asciichars, .memline {
-    display: inline-block;
-    padding-left:1.5em;
+.memline.heading {
+    color: #268bd2;
+}
+
+
+.asciichars {
+    margin-left: 1ch;
+}
+
+.membytes, .asciichars, .memaddr {
+    user-select: text;
+}
+
+.asciichar {
+    width: 1ch;
+    text-align: right;
 }
 
 .memline {
     display: grid;
-    grid-template-columns: 14ch 1fr;
+    grid-template-columns: 14ch auto auto minmax(0, 1fr);
+    column-gap: 1.5ch;
+    line-height: 1.5em;
 }
 
 .membytes, .asciichars {
     display: flex;
     gap: 1ch;
-    line-height: 1.5em;
 }
 
-.membytes div:hover, .asciichars div:hover {
+/* .membytes, .asciichars, .memline {
+    display: inline-block;
+} */
+
+.memline:not(.heading) .membytes div:hover,
+.memline:not(.heading) .asciichars div:hover {
     background-color: var(--first-txt-color);
     color: var(--fourth-bg-color);
 }
 
-.membytes div.selected {
+.membytes div.selected,
+.membytes div:focus {
     background-color: var(--third-bg-color);
+    color: red;
 }
 
 
@@ -552,16 +576,6 @@ h3 {
 .regaddr {
     text-decoration: underline;
     cursor: pointer;
-}
-
-#current_memaddr {
-    margin-left: 9.3em;
-    padding: 0 0.37em 0 0.37em;
-}
-
-.asciichar {
-    width: 2ch;
-    text-align: right;
 }
 
 #controls {

--- a/view/tabs/memdump.js
+++ b/view/tabs/memdump.js
@@ -167,9 +167,9 @@ $("#dumpcontent").on("focusin focusout keyup keydown", ".membytes div[contentedi
                 return;
             }
 
-            if(!/^[a-fA-F0-9]+$/.test(value)) {
-                // TODO: limit input to valid HEX values
-            }
+            // TODO: limit input to valid HEX values
+            // if(!/^[a-fA-F0-9]+$/.test(value)) {
+            // }
 
             if(value.length > 2) {
                 evt.preventDefault();
@@ -199,6 +199,10 @@ $("#dumpcontent").on("focusin focusout keyup keydown", ".membytes div[contentedi
             var current = $this.text().toLowerCase();
             if(current != previous) {
                 var new_value = parseInt(current, 16);
+                if(Number.isNaN(new_value)) {
+                    popout.error(`Invalid value: 0x${$(this).text().toUpperCase()}, converting to 0xFF`);
+                    new_value = 0xFF;
+                }
                 zealcom.mem_write(addr, new_value);
 
                 var c = String.fromCharCode(new_value);


### PR DESCRIPTION
* updated layout of memory view (16 bytes, tighter spacing for smaller displays, labels)
* added editable memory

Editable memory supports tabbing between memory cells, and "over typing" into the next cell (just don't type too fast).

Updated Layout
![image](https://github.com/user-attachments/assets/4b75c583-0215-4613-8a7e-30ef89141345)


Editable Memory
![image](https://github.com/user-attachments/assets/55245f08-8bb0-4b5e-be5a-dab8d242a773)
![image](https://github.com/user-attachments/assets/86ea940b-3aac-46bc-9b0a-9b28d4f42af7)
![image](https://github.com/user-attachments/assets/9179fa64-6c47-48c1-9d8e-967347e77bad)

