### PR TITLE
Emulator - Force Local roms/index.json

### DIFF
--- a/view/readrom.js
+++ b/view/readrom.js
@@ -150,10 +150,7 @@ function processIndex(index) {
     }
     if(index.stable) {
         const stable  = index.stable.map((entry) => {
-            if(params.r == entry.urls) {
-                return to_option(entry, true);
-            }
-            return to_option(entry, false);
+            return to_option(entry, (params.r == entry.urls));
         });
         all_options.push(`<optgroup label="--- Stable ---"  data-type="stable">` + stable.join("") + `</optgroup>`);
     }

--- a/view/readrom.js
+++ b/view/readrom.js
@@ -121,7 +121,7 @@ function processIndex(index) {
             attrs.selected = true;
         }
         const attributes = Object.keys(attrs).reduce((acc,key) => {
-            acc += `${key}`;
+            acc += ` ${key}`;
             if(!['selected', 'disabled'].includes(key) && attrs[key]) {
                 acc += `="${attrs[key]}" `;
             }
@@ -149,7 +149,12 @@ function processIndex(index) {
         all_options.push(`<optgroup label="--- Nightly ---"  data-type="nightly">` + nightly.join("") + `</optgroup>`);
     }
     if(index.stable) {
-        const stable  = index.stable.map((entry) => to_option(entry, false));
+        const stable  = index.stable.map((entry) => {
+            if(params.r == entry.urls) {
+                return to_option(entry, true);
+            }
+            return to_option(entry, false);
+        });
         all_options.push(`<optgroup label="--- Stable ---"  data-type="stable">` + stable.join("") + `</optgroup>`);
     }
 
@@ -198,7 +203,10 @@ async function switchRom() {
         return;
     }
     if(rom_chosen !== compare) {
-        window.history.pushState({}, undefined, `?r=${rom_chosen}`);
+        params.r = rom_chosen;
+        window.history.pushState({}, undefined, `?${Object.keys(params).reduce((a,k) => {
+            return a += `${k}=${params[k]}&`;
+        }, '').slice(0,-1)}`);
         if(reload) {
             window.location.reload();
             return;
@@ -210,7 +218,7 @@ async function switchRom() {
         /* Get the hash for the current binary */
         let hash = $(`#romchoice option[value="${rom_chosen}"]`).attr("hash");
         let data = await readBlobFromUrl(rom_chosen);
-        let hashcomp = await filehash(data, hash);
+        let hashcomp = params.local ? true : await filehash(data, hash);
         if (hashcomp == true) {
             loadRom(data);
         }
@@ -238,7 +246,7 @@ jQuery(() => {
          * Manage the pre-built ROMs list. Available ROMs will be fetched from a remote JSON file that contains
          * names and links to all of the available ROMs, the first one will always be the default.
          */
-        const prebuilt_json_url_host = "https://zeal8bit.com";
+        const prebuilt_json_url_host = params.local ? '' : "https://zeal8bit.com";
         const prebuilt_json_url_path = "/roms/index.json";
         /* Fetch the remote JSON file, and pass the content to the previous function */
         fetch(prebuilt_json_url_host + prebuilt_json_url_path)


### PR DESCRIPTION
* added `local=1` param to force loading the `roms/index.json` locally when hosting the emulator yourself
  - allows users to customize their roms/index.json to support auto-loading custom ROMs
* also added support for keeping/saving multiple params when toggling which rom is selected

Example: `http://127.0.0.1:1145/?r=roms/os_with_romdisk.img&local=1`

The example requires the users local `roms/index.json` to contain an entry like this (ie; inside `nightly`)

```json
    {
      "name": "os_with_romdisk",
      "urls": "roms/os_with_romdisk.img",
      "version": "custom"
    }
```

When combined with a make call like this 
```
make && cp build/os_with_romdisk.img ../Zeal-WebEmulator/roms/os_with_romdisk.img
```
the user can custom build the os_with_romdisk from Zeal-8-Bit-OS and the locally hosted emulator will refresh with the newly built os_with_romdisk - useful for testing drivers, init.bin commands, etc