### PR TITLE
More Auto Loading, Remember Breakpoints and Active Tab

### DIFF
--- a/component/disassembler/disassembler.js
+++ b/component/disassembler/disassembler.js
@@ -419,7 +419,8 @@ function Disassembler() {
      */
     function loadSymbols(content)
     {
-        var lines = content.split("\n");
+        const decoder = new TextDecoder();
+        var lines = decoder.decode(content).split("\n");
         /* Filter the comments by removing the ones containing 'const' */
         lines = lines.filter(e => e.indexOf('; const') == -1);
 

--- a/hardemu/i2c.js
+++ b/hardemu/i2c.js
@@ -256,7 +256,7 @@ function I2C_EEPROM(Zeal, I2C, content) {
     }
 
     function loadFile(binary) {
-        for (var i = 0; i < binary.length; i++)
+        for (var i = 0; i < binary.bytesLength; i++)
             data[i] = binary.charCodeAt(i);
     }
 

--- a/hardemu/machine.js
+++ b/hardemu/machine.js
@@ -414,7 +414,7 @@ class Z80Machine {
 
             var brk = getBreakpoint(next_pc);
             if (brk == null) {
-                addBreakpoint(next_pc, true);
+                addBreakpoint({ address: next_pc, autodelete: true});
             } else {
                 enableBreakpoint(brk);
             }

--- a/hardemu/rom.js
+++ b/hardemu/rom.js
@@ -31,7 +31,7 @@
             for (var i = 0; i < binary.length; i++)
                 data[i] = binary.charCodeAt(i);
         } else {
-            for (var i = 0; i < binary.length; i++)
+            for (var i = 0; i < binary.byteLength; i++)
                 data[i] = binary[i];
         }
     }

--- a/index.html
+++ b/index.html
@@ -283,9 +283,9 @@
 
     <section class="bottompanel">
       <section class="tabs">
-        <div class="tab">Disassemble</div>
+        <div id="disassemble-tab" class="tab">Disassemble</div>
         <div id="memory-tab" class="tab">Memory view</div>
-        <div id="uart-tab" class="tab active">Terminal (UART)</div>
+        <div id="uart-tab" class="tab">Terminal (UART)</div>
         <div id="gamepad-tab" class="tab">Gamepad <span class="tab-status">🔴</span></div>
       </section>
       <section id="memdump" class="panel">

--- a/view/init.js
+++ b/view/init.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Init window
-const left_panel_height = $("#debug").height();
-$("#rightpanel").css('min-height', left_panel_height);
-
 const KB = 1024;
 /* 10MHz frequency */
 const CPUFREQ = 10000000;

--- a/view/init.js
+++ b/view/init.js
@@ -52,6 +52,8 @@ var zealcom = new Zeal8bitComputer();
 const disassembler = new Disassembler();
 const popout = new Popup();
 
+const params = parseQueryParams(window.location.search);
+
 if (typeof electronAPI != 'undefined') {
     $(electronAPI.loaded);
 }

--- a/view/readrom.js
+++ b/view/readrom.js
@@ -150,10 +150,7 @@ function processIndex(index) {
     }
     if(index.stable) {
         const stable  = index.stable.map((entry) => {
-            if(params.r == entry.urls) {
-                return to_option(entry, true);
-            }
-            return to_option(entry, false);
+            return to_option(entry, (params.r == entry.urls));
         });
         all_options.push(`<optgroup label="--- Stable ---"  data-type="stable">` + stable.join("") + `</optgroup>`);
     }

--- a/view/readrom.js
+++ b/view/readrom.js
@@ -9,8 +9,9 @@ const params = parseQueryParams(window.location.search);
 function loadToDevice(dev, loadfile_external_params=[], callback){
     let reader = new FileReader();
     $(reader).on('load', function(e) {
-        let binary = e.target.result;
-        let load_returns = dev.loadFile(binary, ...loadfile_external_params);
+        const binary = e.target.result;
+        const data = new Uint8Array(binary);
+        const load_returns = dev.loadFile(data, ...loadfile_external_params);
         callback(load_returns);
     });
     return reader;
@@ -18,50 +19,46 @@ function loadToDevice(dev, loadfile_external_params=[], callback){
 
 function loadRom(file_rom) {
     /* Read the rom file */
-    if (file_rom) {
-        loadToDevice(zealcom.rom, [], () => {
-            $("#romready").addClass("ready");
-        }).readAsBinaryString(file_rom);
-    }
+    if (!file_rom) return;
+    loadToDevice(zealcom.rom, [], () => {
+        $("#romready").addClass("ready");
+    }).readAsArrayBuffer(file_rom);
 }
 
 function loadMap(file_map) {
     /* If a dump/map file was provided, try to load it */
-    if (file_map) {
-        loadToDevice(disassembler, [], (success) => {
-            if (success) {
-                /* symbols are ready! */
-                $("#symready").addClass("ready");
-            }
-            else {
-                popup.error("Error while loading map file");
-            }
-        }).readAsText(file_map);
-    }
+    if (!file_map) return;
+    loadToDevice(disassembler, [], (success) => {
+        if (success) {
+            /* symbols are ready! */
+            $("#symready").addClass("ready");
+        }
+        else {
+            popup.error("Error while loading map file");
+        }
+    }).readAsArrayBuffer(file_map);
 }
 
 function loadEEPROM(file_eeprom) {
     /* Read the EEPROM image */
-    if (file_eeprom) {
-        loadToDevice(zealcom.eeprom, [], () => {
-            $("#eepromready").addClass("ready");
-        }).readAsBinaryString(file_eeprom);
-    }
+    if (!file_eeprom) return;
+    loadToDevice(zealcom.eeprom, [], () => {
+        $("#eepromready").addClass("ready");
+    }).readAsArrayBuffer(file_eeprom);
 }
 
 function loadCf(file_cf) {
     /** Read the Compact Flash image */
-    if (file_cf) {
-        loadToDevice(zealcom.compactflash, [], () => {
-            $("#cfready").addClass("ready");
-        }).readAsBinaryString(file_cf);
-    }
+    if (!file_cf) return;
+    loadToDevice(zealcom.compactflash, [], () => {
+        $("#cfready").addClass("ready");
+    }).readAsArrayBuffer(file_cf);
 }
 
 function loadRam(file_ram, offset) {
     /* Read the rom file */
     if (file_ram) {
-        loadToDevice(zealcom.ram, [offset], () => {}).readAsBinaryString(file_ram);
+        loadToDevice(zealcom.ram, [offset], () => {}).readAsArrayBuffer(file_ram);
     }
 }
 

--- a/view/readrom.js
+++ b/view/readrom.js
@@ -150,7 +150,10 @@ function processIndex(index) {
     }
     if(index.stable) {
         const stable  = index.stable.map((entry) => {
-            return to_option(entry, (params.r == entry.urls));
+            if(params.r == entry.urls) {
+                return to_option(entry, true);
+            }
+            return to_option(entry, false);
         });
         all_options.push(`<optgroup label="--- Stable ---"  data-type="stable">` + stable.join("") + `</optgroup>`);
     }

--- a/view/readrom.js
+++ b/view/readrom.js
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const params = parseQueryParams(window.location.search);
-
 function loadToDevice(dev, loadfile_external_params=[], callback){
     let reader = new FileReader();
     $(reader).on('load', function(e) {

--- a/view/readrom.js
+++ b/view/readrom.js
@@ -235,24 +235,56 @@ jQuery(() => {
          */
         $("#romload").hide();
         $("#romfile").show();
-    } else {
-        /**
-         * Manage the pre-built ROMs list. Available ROMs will be fetched from a remote JSON file that contains
-         * names and links to all of the available ROMs, the first one will always be the default.
-         */
-        const prebuilt_json_url_host = params.local ? '' : "https://zeal8bit.com";
-        const prebuilt_json_url_path = "/roms/index.json";
-        /* Fetch the remote JSON file, and pass the content to the previous function */
-        fetch(prebuilt_json_url_host + prebuilt_json_url_path)
+        return;
+    }
+
+    /**
+     * Manage the pre-built ROMs list. Available ROMs will be fetched from a remote JSON file that contains
+     * names and links to all of the available ROMs, the first one will always be the default.
+     */
+    const prebuilt_json_url_host = params.local ? '' : "https://zeal8bit.com";
+    const prebuilt_json_url_path = "/roms/index.json";
+    /* Fetch the remote JSON file, and pass the content to the previous function */
+    fetch(prebuilt_json_url_host + prebuilt_json_url_path)
+        .then(response => response.json())
+        .then(response => processIndex(response))
+        .catch(() => {
+            fetch(prebuilt_json_url_path)
             .then(response => response.json())
             .then(response => processIndex(response))
-            .catch(() => {
-                fetch(prebuilt_json_url_path)
-                .then(response => response.json())
-                .then(response => processIndex(response))
-                .catch(switchToAdvancedMode);
-            });
-    }
+            .catch(switchToAdvancedMode);
+        })
+        .then(() => {
+            const promises = [];
+            if(params.cf) {
+                promises.push(
+                    fetch(params.cf)
+                    .then((response) => response.blob())
+                    .then((blob) => {
+                        loadCf(blob);
+                    })
+                );
+            }
+            if(params.m) {
+                promises.push(
+                    fetch(params.m)
+                        .then((response) => response.blob())
+                        .then((blob) => {
+                            loadMap(blob);
+                        })
+                );
+            }
+            if(params.e) {
+                promises.push(
+                    fetch(params.e)
+                        .then((response) => response.blob())
+                        .then((blob) => {
+                            loadEEPROM(blob);
+                        })
+                );
+            }
+            return Promise.all(promises);
+        });
 });
 
 // electron

--- a/view/tabs/memdump.js
+++ b/view/tabs/memdump.js
@@ -147,7 +147,7 @@ $("#memdump").on("click", ".dumpline", function() {
     /* If the address is not in the breakpoint list, add it */
     const brk = getBreakpoint(brkaddr);
     if (brk == null) {
-        addBreakpoint(brkaddr);
+        addBreakpoint({ address: brkaddr });
     } else {
         toggleBreakpoint(brkaddr);
     }

--- a/view/tabs/memdump.js
+++ b/view/tabs/memdump.js
@@ -112,6 +112,7 @@ $("#dumpnow").on("click", function() {
     const virtaddr = parseInt($("#dumpaddr").val(), 16);
     const size = parseInt($("#dumpsize").val());
     setRAMView(virtaddr, size);
+    localStorage.setItem('dump', JSON.stringify({address:virtaddr.toString(16), size}));
 });
 
 $('#dumpaddr, #dumpsize').on('keypress', (evt) => {
@@ -215,10 +216,25 @@ $("#dumpcontent").on("focusin focusout keyup keydown", ".membytes div[contentedi
     }
 });
 
-// $(() => {
-//     $('#dumpaddr').val('4000');
-//     $('#dumpsize').val('128');
-//     setTimeout(() => {
-//         $('#dumpnow').trigger('click');
-//     }, 1200)
-// });
+function dumpMemory(options) {
+    const { address, size } = options;
+    $('#dumpaddr').val(address);
+    $('#dumpsize').val(size ?? 256);
+    setTimeout(() => {
+        $('#dumpnow').trigger('click');
+    }, 100);
+}
+
+$(() => {
+    if(params.dump) {
+        const [address,size = 256] = params.dump.split(',');
+        dumpMemory({address, size});
+        return;
+    }
+
+    const addr = localStorage.getItem('dump');
+    if(addr) {
+        dumpMemory(JSON.parse(addr));
+        return;
+    }
+});

--- a/view/tabs/tabs.js
+++ b/view/tabs/tabs.js
@@ -28,14 +28,12 @@ function setActiveTab(tab) {
 
 $(() => {
     if(params.tab) {
-        console.log('query tab', params.tab);
         setActiveTab(params.tab);
         return;
     }
 
     const lst = localStorage.getItem('tab');
     if(lst) {
-        console.log('storage tab', params.tab);
         setActiveTab(lst);
         return;
     }

--- a/view/tabs/tabs.js
+++ b/view/tabs/tabs.js
@@ -1,18 +1,44 @@
 $(".tab").on("click", function(){
+    setActiveTab($(this).attr('id'));
+    // const $inactiveTab = $('.tab.active');
+    // const $inactivePanel = $(".bottompanel .panel").eq($inactiveTab.index());
+    // const $activeTab = $(this);
+    // const $activePanel = $(".bottompanel .panel").eq($activeTab.index());
+
+    // $inactiveTab.removeClass("active");
+    // $inactivePanel.removeClass("active").trigger('inactive');
+
+    // $activeTab.addClass("active");
+    // $activePanel.addClass("active").trigger('active');
+});
+
+function setActiveTab(tab) {
     const $inactiveTab = $('.tab.active');
     const $inactivePanel = $(".bottompanel .panel").eq($inactiveTab.index());
-    const $activeTab = $(this);
-    const $activePanel = $(".bottompanel .panel").eq($activeTab.index());
-
     $inactiveTab.removeClass("active");
     $inactivePanel.removeClass("active").trigger('inactive');
 
+    const $activeTab = $(`#${tab}`);
+    const $activePanel = $(".bottompanel .panel").eq($activeTab.index());
     $activeTab.addClass("active");
     $activePanel.addClass("active").trigger('active');
-});
+
+    localStorage.setItem('tab', tab);
+}
 
 $(() => {
-    const $activeTab = $('.bottompanel .tabs .tab.active');
-    const $activePanel = $(".bottompanel .panel").eq($activeTab.index());
-    $activePanel.addClass("active").trigger('active');
+    if(params.tab) {
+        console.log('query tab', params.tab);
+        setActiveTab(params.tab);
+        return;
+    }
+
+    const lst = localStorage.getItem('tab');
+    if(lst) {
+        console.log('storage tab', params.tab);
+        setActiveTab(lst);
+        return;
+    }
+
+    setActiveTab('uart');
 });


### PR DESCRIPTION
* refactor deprecated readAsBinaryString with readAsArrayBuffer
* store breakpoints in localStorage, and restore them on refresh
* load CF, EEPROM and MAP files from query params
* remember active tab, accept `tab=uart-tab` param to force tab