### PR TITLE
Improved T-State Debugger

### DIFF
--- a/hardemu/screen.js
+++ b/hardemu/screen.js
@@ -1073,7 +1073,7 @@ function VideoChip(Zeal, PIO, scale) {
     /**
      * @brief Video configuration sees a write, address is relative to this space
      */
-    var previous_tstate = 0;
+    var previous_tstate = {};
     function vConfigWrite(address, value) {
         switch (address) {
             case 0x0:
@@ -1091,11 +1091,16 @@ function VideoChip(Zeal, PIO, scale) {
             case 0x6:
                 /* Benchmark! */
                 const current_states = zealcom.getTstates();
-                const diff = current_states - previous_tstate;
-                const micros = diff/10
-                const millis = micros/1000;
-                console.log("Elapsed T-states: " + diff + " (" + millis + " ms)");
-                previous_tstate = current_states;
+                const tracked = previous_tstate[value];
+                if(tracked != undefined) {
+                    delete previous_tstate[value];
+                    const diff = current_states - tracked;
+                    const micros = diff/10
+                    const millis = micros/1000;
+                    console.log(`Elapsed T-states (${value}): ${diff} (${millis}ms)`);
+                } else {
+                    previous_tstate[value] = current_states;
+                }
             case 0xe: mapping.io_bank = value & 0x3f;
                 break;
             case 0xf: mapping.mem_start = (value & 0x1f) >> (22 - 5);


### PR DESCRIPTION
* support for tracking multiple t-state counters by writing the counter number to 0x86

Example usage:
```
__sfr __at(0x86) debug_register; // t-state counter
#define DEBUG_COUNT(counter) debug_register = counter;

while(1) {
  DEBUG_COUNT(2); // start
  DEBUG_COUNT(4); // start
  update();
  DEBUG_COUNT(4); // display
  
  gfx_wait_vblank(&vctx);
  DEBUG_COUNT(1); // start
  DEBUG_COUNT(3); // start
  draw();
  DEBUG_COUNT(3); // display
  gfx_wait_end_vblank(&vctx);
  DEBUG_COUNT(1); // display

  DEBUG_COUNT(2); // display 
}
```

Example output
```
Elapsed T-states (1): 13992 (1.3992ms)
Elapsed T-states (2): 166653 (16.6653ms)
Elapsed T-states (4): 35905 (3.5905ms)
Elapsed T-states (3): 6244 (0.6244ms)
Elapsed T-states (1): 13992 (1.3992ms)
Elapsed T-states (2): 166615 (16.6615ms)
Elapsed T-states (4): 3427 (0.3427ms)
Elapsed T-states (3): 6244 (0.6244ms)
Elapsed T-states (1): 13954 (1.3954000000000002ms)
Elapsed T-states (2): 166627 (16.6627ms)
Elapsed T-states (4): 3835 (0.3835ms)
Elapsed T-states (3): 6244 (0.6244ms)
Elapsed T-states (1): 13993 (1.3993ms)
Elapsed T-states (2): 166656 (16.665599999999998ms)
```