### PR TITLE
Video Tab - Crisper Tiles

### DIFF
--- a/view/css/emulator.css
+++ b/view/css/emulator.css
@@ -583,6 +583,7 @@ hr {
             width: 64px;
             height: 64px;
             cursor: help;
+            image-rendering: pixelated;
         }
     }
 


### PR DESCRIPTION
* add image-rendering: pixelated to make the tiles in the video tab crisper looking