### PR TITLE
Video - Sprites Sub-panel, and Tilemap Layers

### DIFF
--- a/hardemu/screen.js
+++ b/hardemu/screen.js
@@ -509,6 +509,10 @@ function Sprites(Tileset)
             ctx.drawImage(sprite.canvas, x, y);
         }
     }
+
+    this.dump = function() {
+        return {attributes};
+    }
 }
 
 var TStateLogger = false;
@@ -1389,6 +1393,9 @@ function VideoChip(Zeal, PIO, scale) {
             layer0: canvas,
             layer1: canvas_layer1,
             sprites,
+            gfx_cfg,
+            text_cfg,
+            video_cfg,
         };
     }
 

--- a/index.html
+++ b/index.html
@@ -369,7 +369,11 @@
             Show Tileset
           </label>
           <label>
-            <input type="checkbox" id="video-tilemap" class="toggle" name="tilemap" checked />
+            <input type="checkbox" id="video-sprites" class="toggle" name="sprites" />
+            Show Sprites
+          </label>
+          <label>
+            <input type="checkbox" id="video-tilemap" class="toggle" name="tilemap" />
             Show Tilemap
           </label>
         </div>
@@ -385,8 +389,44 @@
           <summary>Tileset</summary>
           <div class="tileset"></div>
         </details>
+        <details class="sub-panel" name="sprites" open>
+          <summary>Sprites</summary>
+          <div class="panel-toolbar">
+            <label>
+              <input type="checkbox" class="data" name="sprites-empty" />
+              Hide Empty
+            </label>
+            <label>
+              <input type="checkbox" class="data" name="sprites-details" />
+              Show Details
+            </label>
+          </div>
+          <div class="sprites"></div>
+        </details>
         <details class="sub-panel" name="tilemap">
           <summary>Tilemap</summary>
+          <div class="panel-toolbar">
+            <label>
+              <input type="checkbox" class="data" name="tilemap-layer0" />
+              Layer0
+            </label>
+            <label>
+              <input type="checkbox" class="data" name="tilemap-layer1" />
+              Layer1
+            </label>
+            <label>
+              <input type="checkbox" class="data" name="tilemap-sprites" />
+              Sprites
+            </label>
+            <label>
+              <input type="checkbox" class="data" name="tilemap-grid" />
+              Show Grid
+            </label>
+            <label>
+              <input type="color" class="data" name="tilemap-grid-color" value="#ff0000" />
+              Grid Color
+            </label>
+          </div>
           <div class="tilemap"></div>
         </details>
       </section>

--- a/view/css/emulator.css
+++ b/view/css/emulator.css
@@ -627,24 +627,25 @@ hr {
         --grid-item--max-width: var(--grid-width, 320px);
 
         /** the bottom cells overflow, so just assume full borders **/
-        border: 1px dashed var(--grid-color);
+        &.grid {
+            border: 1px dashed var(--grid-color);
+            .tilemap-overlay {
+                position: absolute;
+                top: 0;
+                left: 0;
+                max-width: 100%;
+                aspect-ratio: 1280 / 640;
+                display: grid;
 
-        .tilemap-overlay {
-            position: absolute;
-            top: 0;
-            left: 0;
-            max-width: 100%;
-            aspect-ratio: 1280 / 640;
-            display: grid;
+                --grid-item--max-width: calc(100% / var(--grid-column-count));
+                grid-gap: 0px;
+                grid-template-columns: repeat(auto-fill, minmax(max(100px, var(--grid-item--max-width)), 1fr));
 
-            --grid-item--max-width: calc(100% / var(--grid-column-count));
-            grid-gap: 0px;
-            grid-template-columns: repeat(auto-fill, minmax(max(100px, var(--grid-item--max-width)), 1fr));
-
-            > div {
-                aspect-ratio: 4 / 3;
-                border-right: 1px dashed var(--grid-color);
-                border-bottom: 1px dashed var(--grid-color);
+                > div {
+                    aspect-ratio: 4 / 3;
+                    border-right: 1px dashed var(--grid-color);
+                    border-bottom: 1px dashed var(--grid-color);
+                }
             }
         }
     }

--- a/view/css/emulator.css
+++ b/view/css/emulator.css
@@ -396,11 +396,18 @@ hr {
 
 .panel .panel-toolbar label {
     display: flex;
+    align-items: center;
     gap: 1ch;
+
+    cursor: pointer;
+    &:hover {
+        color: var(--second-txt-color);
+        text-decoration: underline;
+    }
 }
 
 .sub-panel {
-    margin-inline-start: 1em;
+    margin-inline: 1em;
     margin-top: 1em;
     padding: 1em;
     border-radius: 8px;
@@ -430,6 +437,11 @@ hr {
             content: "+";
             padding-right: 1ch;
         }
+    }
+
+    .panel-toolbar {
+        padding-block: 0;
+        margin-bottom: 1em;
     }
 
     &[open] > summary {
@@ -563,6 +575,14 @@ hr {
         flex-direction: column;
     }
 
+    .sub-panel {
+        canvas {
+            max-width: 100%;
+            image-rendering: pixelated;
+        }
+        margin-bottom: 1em;
+    }
+
     .palette {
         display: grid;
         gap: .5em;
@@ -576,6 +596,7 @@ hr {
     }
 
     .fonts,
+    .sprites,
     .tileset {
         --gap: 1ch;
         --column: 64px;
@@ -586,7 +607,6 @@ hr {
             width: var(--column);
             aspect-ratio: 1;
             cursor: help;
-            image-rendering: pixelated;
         }
     }
 
@@ -597,9 +617,56 @@ hr {
         }
     }
 
-    .layers {
-        > canvas {
+    .tilemap {
+        position: relative;
+        overflow: hidden;
+        aspect-ratio: 1280 / 640;
+
+        --grid-color: transparent;
+        --grid-column-count: var(--columns, 4);
+        --grid-item--max-width: var(--grid-width, 320px);
+
+        /** the bottom cells overflow, so just assume full borders **/
+        border: 1px dashed var(--grid-color);
+
+        .tilemap-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
             max-width: 100%;
+            aspect-ratio: 1280 / 640;
+            display: grid;
+
+            --grid-item--max-width: calc(100% / var(--grid-column-count));
+            grid-gap: 0px;
+            grid-template-columns: repeat(auto-fill, minmax(max(100px, var(--grid-item--max-width)), 1fr));
+
+            > div {
+                aspect-ratio: 4 / 3;
+                border-right: 1px dashed var(--grid-color);
+                border-bottom: 1px dashed var(--grid-color);
+            }
+        }
+    }
+
+    .sprites.detailed {
+        grid-template-columns: repeat(auto-fit, 300px);
+        .details {
+            display: grid;
+            padding: .5em;
+            background-color: var(--second-bg-color);
+            border-radius: 8px;
+            align-items: center;
+            justify-content: center;
+            column-gap: 10px;
+            grid-template-columns: var(--column) 1fr;
+            > canvas {
+                width: var(--column);
+                aspect-ratio: 1;
+            }
+            > pre {
+                margin: 0px;
+            }
         }
     }
 }

--- a/view/tabs/video.js
+++ b/view/tabs/video.js
@@ -93,11 +93,11 @@
     /** Sprites **/
     const $sprites = $('#video .sprites').empty();
     const { attributes: sprite_attrs } = sprites.dump();
-    console.log('sprites', sprite_attrs);
     const sprite_count = sprite_attrs.length
     const sprite_empty = panels['sprites']?.data?.['sprites-empty'] ?? true;
     const sprite_details = panels['sprites']?.data?.['sprites-details'] ?? false;
     if(sprite_details) $sprites.addClass('detailed');
+    else $sprites.removeClass('detailed');
     for(let i = 0; i < sprite_count; i++) {
       const sprite = sprite_attrs[i];
       if(sprite_empty && sprite.tile == 0) continue;
@@ -157,12 +157,14 @@ Palette: ${sprite.palette}</pre>`)
     if(data['tilemap-layer0']) ctx.drawImage(layer0.offscreenCanvas, 0, 0, 1280, 640, 0, 0, 1280, 640);
     if(data['tilemap-layer1']) ctx.drawImage(layer1, 0, 0, 1280, 640, 0, 0, 1280, 640);
     if(data['tilemap-sprites']) sprites.drawSprites(canvas);
+
+    const grid_color = panels['tilemap']?.data?.['tilemap-grid-color'] ?? '#ff0000';
+    $tilemap.css({
+      '--grid-color': `${grid_color}`
+    });
     $tilemap.append(canvas);
     if(show_cells) {
-      const grid_color = panels['tilemap']?.data?.['tilemap-grid-color'] ?? '#ff0000';
-      $tilemap.css({
-        '--grid-color': `${grid_color}`
-      });
+      $tilemap.addClass('grid');
       const $overlay = $('<div class="tilemap-overlay"></div>');
       $overlay.css({
         'width': 1280,
@@ -175,8 +177,9 @@ Palette: ${sprite.palette}</pre>`)
       for(let i = 0; i < cells; i++) {
         $overlay.append($('<div></div>'));
       }
+    } else {
+      $tilemap.removeClass('grid');
     }
-    console.log('configs', { gfx_cfg, text_cfg, video_cfg });
   });
 
   $('details', $tab).on('toggle', function() {

--- a/view/tabs/video.js
+++ b/view/tabs/video.js
@@ -1,5 +1,13 @@
 (() => {
-  var $tab = $('#video');
+  // copied from screen.js, ... proper module exports would be better?
+  const MODE_TEXT_640     = 0;
+  const MODE_TEXT_320     = 1;
+  const MODE_GFX_640_8BIT = 4;
+  const MODE_GFX_320_8BIT = 5;
+  const MODE_GFX_640_4BIT = 6;
+  const MODE_GFX_320_4BIT = 7;
+
+  const $tab = $('#video');
   const _panels = localStorage.getItem('video-panels');
   let panels;
   const savePanels = () => {
@@ -11,7 +19,24 @@
       "palette": { "open": true, "visible": true },
       "fonts": { "open": true, "visible": false },
       "tileset": { "open": true, "visible": true },
-      "tilemap": { "open": false, "visible": false }
+      "sprites": {
+        "open": false,
+        "visible": false,
+        "data": {
+          "sprites-empty": true,
+        }
+      },
+      "tilemap": {
+        "open": false,
+        "visible": false,
+        "data": {
+          "tilemap-layer0": true,
+          "tilemap-layer1": true,
+          "tilemap-sprites": true,
+          "tilemap-grid": true,
+          "tilemap-grid-color": "#ff0000",
+        }
+      }
     }
     savePanels();
   } else {
@@ -23,8 +48,9 @@
   });
 
   $('#video-dump').on('click', () => {
-    const { tileset, palette, layer0, layer1, sprites, font } = zealcom.vchip.dump();
+    const { tileset, palette, layer0, layer1, sprites, font, gfx_cfg, text_cfg, video_cfg } = zealcom.vchip.dump();
 
+    /** Palette **/
     const $palette = $('#video .palette').empty();
     const palette888 = palette.getPalette();
     const background = palette888[0].toString(16).padStart(6, '0');
@@ -35,6 +61,7 @@
       `);
     });
 
+    /** Font **/
     const $font = $('#video .fonts').empty();
     for(let i = 0; i < 256; i++) {
       const img = font.getCharacterImg(i, [0,0,0], [255,255,255]);
@@ -42,11 +69,12 @@
       $(canvas).attr('title', `Char ${i}`).css('background-color', `#${background}`);
       canvas.width = 8;
       canvas.height = 12;
-      var ctx = canvas.getContext('2d');
+      const ctx = canvas.getContext('2d');
       ctx.putImageData(img, 0, 0);
       $font.append(canvas);
     }
 
+    /** Tiles **/
     const $tileset = $('#video .tileset').empty();
     const mode8bit = tileset.getColorMode8Bit();
     const tile_count = mode8bit ? 256 : 512;
@@ -57,26 +85,101 @@
       $(canvas).attr('title', `Tile ${i}`).css('background-color', `#${background}`);
       canvas.width = 16;
       canvas.height = 16;
-      var ctx = canvas.getContext('2d');
+      const ctx = canvas.getContext('2d');
       ctx.putImageData(tile, 0, 0);
       $tileset.append(canvas);
     };
 
+    /** Sprites **/
+    const $sprites = $('#video .sprites').empty();
+    const { attributes: sprite_attrs } = sprites.dump();
+    console.log('sprites', sprite_attrs);
+    const sprite_count = sprite_attrs.length
+    const sprite_empty = panels['sprites']?.data?.['sprites-empty'] ?? true;
+    const sprite_details = panels['sprites']?.data?.['sprites-details'] ?? false;
+    if(sprite_details) $sprites.addClass('detailed');
+    for(let i = 0; i < sprite_count; i++) {
+      const sprite = sprite_attrs[i];
+      if(sprite_empty && sprite.tile == 0) continue;
+      const canvas = document.createElement('canvas');
+      $(canvas).attr('title', `Sprite ${i}`).css('background-color', `#${background}`);
+      canvas.width = 16;
+      canvas.height = 16;
+      const ctx = canvas.getContext('2d');
+      ctx.putImageData(sprite.img, 0, 0);
+      if(!sprite_details) {
+        $sprites.append(canvas);
+      } else {
+        const $details = $('<div class="details"></div>');
+        $details.append(canvas);
+        $details.append(`<pre>Index: ${i} Tile: ${sprite.tile}
+X: ${sprite.x}, Y: ${sprite.y}
+Flip X: ${sprite.flip_x}, Flip Y: ${sprite.flip_y}
+Palette: ${sprite.palette}</pre>`)
+        $sprites.append($details);
+      }
+    }
+
+    /** Tilemap **/
+    const data = panels['tilemap'].data;
     const $tilemap = $('#video .tilemap').empty();
     const canvas = document.createElement('canvas');
-    canvas.width = 1280;
-    canvas.height = 640;
+    let width = 1280;
+    let height = 640;
+    let show_cells = panels['tilemap']?.data?.['tilemap-grid'] ?? true;
+    switch(video_cfg.mode) {
+      case MODE_TEXT_640: show_cells = false; width = 640; height = 480; break;
+      case MODE_TEXT_320: show_cells = false; width = 320; height = 240; break;
+      case MODE_GFX_640_8BIT: // fall thru
+      case MODE_GFX_640_4BIT:
+        $tilemap.css({
+          '--grid-width': 640,
+          '--columns': 2,
+        });
+        break;
+      case MODE_GFX_320_8BIT: // fall thru
+      case MODE_GFX_320_4BIT:
+        $tilemap.css({
+          '--grid-width': 320,
+          '--columns': 4,
+        });
+        break;
+    }
+
+    $(canvas).attr({
+      'width': width,
+      'height': height,
+    }).css({
+      'background-color': `#${background}`,
+      'aspect-ration': `${width} / ${height}`
+    });
     ctx = canvas.getContext('2d');
-    // ctx.putImageData(layer0.getImageData(0, 0, 1280, 640), 0, 0);
-    // ctx.putImageData(layer1.getImageData(0, 0, 1280, 640), 0, 0);
-    ctx.drawImage(layer0.offscreenCanvas, 0, 0, 1280, 640, 0, 0, 1280, 640);
-    ctx.drawImage(layer1, 0, 0, 1280, 640, 0, 0, 1280, 640);
-    sprites.drawSprites(canvas);
+    if(data['tilemap-layer0']) ctx.drawImage(layer0.offscreenCanvas, 0, 0, 1280, 640, 0, 0, 1280, 640);
+    if(data['tilemap-layer1']) ctx.drawImage(layer1, 0, 0, 1280, 640, 0, 0, 1280, 640);
+    if(data['tilemap-sprites']) sprites.drawSprites(canvas);
     $tilemap.append(canvas);
+    if(show_cells) {
+      const grid_color = panels['tilemap']?.data?.['tilemap-grid-color'] ?? '#ff0000';
+      $tilemap.css({
+        '--grid-color': `${grid_color}`
+      });
+      const $overlay = $('<div class="tilemap-overlay"></div>');
+      $overlay.css({
+        'width': 1280,
+        'aspect-ration': `${width} / ${height}`,
+      });
+      $tilemap.append($overlay);
+      const cols = Math.ceil(1280 / video_cfg.width);
+      const rows = Math.ceil(640 / video_cfg.height);
+      const cells = cols * rows;
+      for(let i = 0; i < cells; i++) {
+        $overlay.append($('<div></div>'));
+      }
+    }
+    console.log('configs', { gfx_cfg, text_cfg, video_cfg });
   });
 
   $('details', $tab).on('toggle', function() {
-    console.log('toggle', this);
     const panel = $(this).attr('name');
     panels[panel].open = this.open;
     savePanels();
@@ -88,21 +191,42 @@
     else $panel.hide();
 
     panels[panel] = {
+      ...panels[panel],
       visible: toggle,
     };
     savePanels();
   }
 
+  const setData = (panel, attr, value) => {
+    if(!panels[panel].data) panels[panel].data = {};
+    panels[panel].data[attr] = value;
+    savePanels();
+  }
+
   $('input.toggle', $tab).on('change', function() {
-    var panel = $(this).attr('name');
-    var checked = $(this).is(':checked');
+    const panel = $(this).attr('name');
+    const checked = $(this).is(':checked');
     togglePanel(panel, checked);
   });
 
+  $('input.data', $tab).on('change', function() {
+    const $input = $(this);
+    const $panel = $input.closest('.sub-panel');
+    const panel = $panel.attr('name');
+    const attr = $input.attr('name');
+    let val = $input.val();
+    const type = $input.attr('type');
+    switch(type) {
+      case 'checkbox':
+        val = $input.is(':checked');
+        break;
+    }
+    setData(panel, attr, val);
+  });
+
   for(k in panels) {
-    const {visible, open} = panels[k];
+    const {visible, open, data} = panels[k];
     const $panel = $(`.sub-panel[name=${k}]`);
-    console.log('panel', { visible, open});
     $(`input[name=${k}]`).prop('checked', visible);
     if(visible) {
       $panel.show();
@@ -114,6 +238,17 @@
       $panel.attr('open', true);
     } else {
       $panel.attr('open', false);
+    }
+
+    if(data) {
+      for(j in data) {
+        const val = data[j];
+        if(typeof val == 'boolean') {
+          $(`input[name=${j}`, $panel).prop('checked', data[j]);
+        } else {
+          $(`input[name=${j}`, $panel).val(val);
+        }
+      }
     }
   }
 })();


### PR DESCRIPTION
* add Layers and Grid to Tilemap
* add Sprites sub-panel with optional detail view

Sprites sub-panel supports "Hide Empty", which does not show any sprite with Tile Index 0 (background tile)

640x480 Mode - Show Grid
![image](https://github.com/user-attachments/assets/e9328d20-2ad5-42d6-acf4-653ea3ba4619)

320x240 Mode - Show Grid, changed color
![image](https://github.com/user-attachments/assets/e0544a81-2f3a-47ef-8cdf-cd2dcf2498b5)

320x240 Mode - Disable Layer0, Layer1
![image](https://github.com/user-attachments/assets/f240c0aa-06a0-4114-bf91-44f3098280a0)

Show Sprites - Show Details
![image](https://github.com/user-attachments/assets/dfbf4e2c-68fc-4357-97f5-e50cbe592404)

Show Sprites - No Details
![image](https://github.com/user-attachments/assets/7801782b-8dbc-4e17-b63a-b4bb06ca8a7c)
